### PR TITLE
Revert "chore(config): remove outdated migu cookie setting"

### DIFF
--- a/luasrc/model/cbi/unblockneteasemusic/main.lua
+++ b/luasrc/model/cbi/unblockneteasemusic/main.lua
@@ -60,6 +60,11 @@ o.placeholder = "wmid=; session_key="
 o.datatype = "string"
 o:depends("use_custom_cookie", 1)
 
+o = s:option(Value, "migu_cookie", translate("Migu Cookie"))
+o.description = translate("通过抓包手机客户端请求获取，需要 aversionid 值")
+o.datatype = "string"
+o:depends("use_custom_cookie", 1)
+
 o = s:option(Value, "qq_cookie", translate("QQ Cookie"))
 o.description = translate("在 y.qq.com 获取，需要 uin 和 qm_keyst值 ")
 o.placeholder = "uin=; qm_keyst="

--- a/root/etc/init.d/unblockneteasemusic
+++ b/root/etc/init.d/unblockneteasemusic
@@ -138,6 +138,7 @@ start_service() {
 	procd_append_param env JSON_LOG="true"
 
 	append_param_env "config" "joox_cookie" "JOOX_COOKIE"
+	append_param_env "config" "migu_cookie" "MIGU_COOKIE"
 	append_param_env "config" "qq_cookie" "QQ_COOKIE"
 	append_param_env "config" "youtube_key" "YOUTUBE_KEY"
 	append_param_env "config" "self_issue_cert_crt" "SIGN_CERT" "/usr/share/$NAME/core/server.crt"

--- a/root/usr/share/unblockneteasemusic/debugging.sh
+++ b/root/usr/share/unblockneteasemusic/debugging.sh
@@ -30,6 +30,7 @@ echo -e "luci-app-unblockneteasmusic info:"
 opkg info "luci-app-unblockneteasemusic"
 ls -lh "/etc/config/$NAME" "/etc/init.d/$NAME" "/usr/share/$NAME"
 cat "/etc/config/$NAME" | sed -e "s,joox_cookie .*,joox_cookie 'set',g" \
+	-e "s,migu_cookie .*,migu_cookie 'set',g" \
 	-e "s,qq_cookie .*,qq_cookie 'set',g" \
 	-e "s,youtube_key .*,youtube_key 'set',g" \
 	-e "s,proxy_server_ip .*,proxy_server_ip 'set',g"
@@ -58,7 +59,11 @@ netstat -tlpen | grep "$unm_ports" || echo -e "No instance found on port $unm_po
 echo -e "\n"
 
 echo -e "PROCD running info:"
-running_stat="$(ubus call service list '{"name": "unblockneteasemusic", "verbose": true}' | sed -e 's,"YOUTUBE_KEY".*","YOUTUBE_KEY": "set",g' -e 's,"QQ_COOKIE".*","QQ_COOKIE": "set",g')"
+running_stat="$(ubus call service list '{"name": "unblockneteasemusic", "verbose": true}' | \
+	sed -e 's,"JOOX_COOKIE".*","JOOX_COOKIE": "set",g' \
+	    -e 's,"MIGU_COOKIE".*","MIGU_COOKIE": "set",g' \
+	    -e 's,"QQ_COOKIE".*","QQ_COOKIE": "set",g' \
+	    -e 's,"YOUTUBE_KEY".*","YOUTUBE_KEY": "set",g')"
 [ "$(echo -e "$running_stat" | jsonfilter -e "@.$NAME.instances.$NAME.running")" == "true" ] || is_stopped=1
 echo -e "$running_stat"
 


### PR DESCRIPTION
The new api is broken. Have to revert to the old one.

This reverts commit 2ac1b372b5e70976bfab8d53f7c1e331f3a321bb.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>